### PR TITLE
[WIP]メッセージ送信機能の非同期化

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -68,3 +68,5 @@ gem 'pry-rails'
 gem 'carrierwave'
 
 gem 'mini_magick'
+
+gem 'jquery-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -125,6 +125,10 @@ GEM
       ruby-vips (>= 2.0.17, < 3)
     jbuilder (2.10.0)
       activesupport (>= 5.0.0)
+    jquery-rails (4.4.0)
+      rails-dom-testing (>= 1, < 3)
+      railties (>= 4.2.0)
+      thor (>= 0.14, < 2.0)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -294,6 +298,7 @@ DEPENDENCIES
   font-awesome-sass
   haml-rails (>= 1.0, <= 2.0.1)
   jbuilder (~> 2.7)
+  jquery-rails
   listen (>= 3.0.5, < 3.2)
   mini_magick
   mysql2 (>= 0.4.4)

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,2 +1,3 @@
 //= link_tree ../images
+//= link_directory ../javascripts .js
 //= link_directory ../stylesheets .css

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,0 +1,3 @@
+//= require jquery
+//= require rails-ujs
+//= require_tree .

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,0 +1,64 @@
+$(function(){
+  function buildHTML(message){
+    if ( message.image ) {
+      let html = `<div class="main-chat__message-list__group-message">
+                    <div class="main-chat__message-list__group-message__list">
+                      <div class="main-chat__message-list__group-message__list__name">
+                        ${message.user_nickname}
+                      </div>
+                      <div class="main-chat__message-list__group-message__list__dateinfo">
+                        ${message.created_at}
+                      </div>
+                    </div>
+                    <div class="Message">
+                      <p class="Message__content">
+                        ${message.content}
+                      </p>
+                      <img class="Message__image" src="${message.image}">
+                    </div>
+                </div>`
+              return html;
+    } else {
+      let html = `<div class="main-chat__message-list__group-message">
+                    <div class="main-chat__message-list__group-message__list">
+                      <div class="main-chat__message-list__group-message__list__name">
+                        ${message.user_nickname}
+                      </div>
+                      <div class="main-chat__message-list__group-message__list__dateinfo">
+                        ${message.created_at}
+                      </div>
+                    </div>
+                    <div class="Message">
+                      <p class="Message__content">
+                        ${message.content}
+                      </p>
+                    </div>
+                  </div>`
+                  return html;
+    };
+  }
+
+  $('.new-message').on('submit', function(e){
+    e.preventDefault();
+    let formDate = new FormData(this);
+    let url = $(this).attr('action');
+    $.ajax({
+      url: url,
+      type: 'POST',
+      data: formDate,
+      dataType: 'json',
+      processData: false,
+      contentType: false
+    })
+    .done(function(data){
+      let html = buildHTML(data)
+      $('.main-chat__message-list').append(html)
+      $('form')[0].reset();
+      $('.main-chat__message-list').animate({ scrollTop: $('.main-chat__message-list')[0].scrollHeight});
+      $(".submit-btn").prop("disabled", false);
+    })
+    .fail(function() {
+      alert('メッセージ送信に失敗しました');
+    });
+  });
+});

--- a/app/assets/stylesheets/modules/_messages.scss
+++ b/app/assets/stylesheets/modules/_messages.scss
@@ -45,6 +45,7 @@
         background-color: #fafafa;
         height: calc(100vh - 190px);
         padding: 35px 40px 0;
+        overflow: scroll;
           &__group-message{
             margin-bottom: 46px;
               .message{

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -9,7 +9,9 @@ class MessagesController < ApplicationController
   def create
     @message = @group.messages.new(message_params)
     if @message.save
-      redirect_to group_messages_path(@group), notice: 'メッセージが送信されました'
+      respond_to do |format|
+        format.json
+      end
     else
       @messages = @group.messages.includes(:user)
       flash.now[:alert] = 'メッセージを入力してください'

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -6,7 +6,7 @@
     = csrf_meta_tags
     = csp_meta_tag
     = stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload'
-    = javascript_pack_tag 'application', 'data-turbolinks-track': 'reload'
+    = javascript_include_tag 'application'
   %body
     = render 'layouts/notifications'
     = yield

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,0 +1,4 @@
+json.user_nickname @message.user.nickname
+json.created_at @message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+json.content @message.content
+json.image @message.image_url

--- a/config/application.rb
+++ b/config/application.rb
@@ -16,5 +16,6 @@ module ChatSpace
       g.test_framework false
     end
     config.i18n.default_locale = :ja
+    config.time_zone = 'Tokyo'
   end
 end


### PR DESCRIPTION
#what
メッセージ送信をする際に非同期化を行い、リロードせずにメッセージが教示されるようにした。

https://gyazo.com/6f8c1c48758334b68a2284e6ab0825c2

https://gyazo.com/4e7d7665f4cbcf8ab231d60f38fd64e8

https://gyazo.com/29c8480f454e213bfc856d98992a6f97

https://gyazo.com/d406c52a45abf2b4a35408b4069b9f61

https://gyazo.com/c88ec32b284bf5f5ce273bbf174c9202

#why
メッセージを送信した際にその都度画面がリロードされなくても表示されるようになり処理スピードが速くなるため。
投稿文が最下部に表示されるので、その文章を投稿できたことが一目でわかるようにするため。

